### PR TITLE
feat: add values for dnsPolicy and hostNetwork

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "image-mapper.fullname" . }}
       automountServiceAccountToken: true
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      hostNetwork: {{ .Values.hostNetwork }}
       containers:
       - name: webhook
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -47,6 +47,8 @@ resources:
     memory: 128Mi
     # -- CPU request
     cpu: 100m
+dnsPolicy: ClusterFirst
+hostNetwork: false
 
 webhook:
   certManager:


### PR DESCRIPTION
**What happened**
When deploying webhook to the EKS cluster with custom CNI plugin such as Calico, Weave, and so on.
`hostNetwork` must be set to true due EKS api cannot access the pod network

Ref: 
https://github.com/aws/containers-roadmap/issues/1215
https://github.com/aws/karpenter-provider-aws/issues/1602

**Solution**
Let's set the possibility to modify `dnsPolicy` and `hostNetwork` to support this use-case.
The idea is to set default value to the default from k8s so this feature won't introduce regression.

assign @cbarbian-sap @zdenko-kovac 