### PR TITLE
feat/configurable-service-and-webhook: make service port and webhook settings customizable

### DIFF
--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -7,9 +7,9 @@ metadata:
     {{- include "image-mapper.labels" . | nindent 4 }}
 spec:
   ports:
-    - port: 443
-      protocol: TCP
-      targetPort: webhooks
-      name: https
+    - port: {{ .Values.service.port }}
+      protocol: {{ .Values.service.protocol | default "TCP" }}
+      targetPort: {{ .Values.service.targetPort }}
+      name: {{ .Values.service.name | default "https" }}
   selector:
     {{- include "image-mapper.selectorLabels" . | nindent 4 }}

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -134,8 +134,8 @@ webhooks:
     {{- with .Values.webhook.namespaceSelector.matchExpressions }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-  matchPolicy: Equivalent
-  sideEffects: None
-  timeoutSeconds: 10
-  failurePolicy: Fail
-  reinvocationPolicy: IfNeeded
+  matchPolicy: {{ .Values.webhook.matchPolicy | default "Equivalent" }}
+  sideEffects: {{ .Values.webhook.sideEffects | default "None" }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds | default 10 }}
+  failurePolicy: {{ .Values.webhook.failurePolicy | default "Fail" }}
+  reinvocationPolicy: {{ .Values.webhook.reinvocationPolicy | default "IfNeeded" }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -71,6 +71,25 @@ webhook:
     # -- Namespace selector matchExpressions, used by webhook
     matchExpressions: []
 
+  # -- Timeout in seconds for the webhook call. Must be between 1 and 30 seconds.
+  timeoutSeconds: 10
+
+  # -- What to do if the webhook call fails.
+  # -- Valid values: "Ignore", "Fail"
+  failurePolicy: Fail
+
+  # -- Policy for matching incoming requests to webhook rules.
+  # -- Valid values: "Exact", "Equivalent"
+  matchPolicy: Equivalent
+
+  # -- Indicates whether calling the webhook has side effects.
+  # -- Valid values: "None", "Some"
+  sideEffects: None
+
+  # -- Reinvocation policy defines whether the webhook should be called again
+  # -- Valid values: "Never", "IfNeeded"
+  reinvocationPolicy: IfNeeded
+
 # -- Log level
 logLevel: 0
 # -- Mapping rules
@@ -79,3 +98,14 @@ mapping: []
 labelsAddedIfModified: {}
 # -- Annotations to set on mutated pods
 annotationsAddedIfModified: {}
+
+# -- Service configuration
+service:
+  # -- The external port exposed by the service
+  port: 443
+  # -- Protocol to use (TCP/UDP). Default is TCP.
+  protocol: TCP
+  # -- Target port on the pod (usually a named port or containerPort)
+  targetPort: webhooks
+  # -- Name for the port (used for things like Prometheus scraping and readability)
+  name: https


### PR DESCRIPTION
- Service port, protocol, targetPort, and name moved to values.yaml
- Webhook configuration made customizable:
  - timeoutSeconds
  - failurePolicy
  - matchPolicy
  - sideEffects
  - reinvocationPolicy
- Added comments to values.yaml for clarity